### PR TITLE
fix: add Liberation fonts for Chromium

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const readFileAsync = util.promisify(fs.readFile.bind(fs));
 const DEPENDENCIES = {
   'ubuntu18.04': {
     chromium: [
+      'fonts-liberation',
       'libasound2',
       'libatk-bridge2.0-0',
       'libatk1.0-0',
@@ -115,6 +116,7 @@ const DEPENDENCIES = {
 
   'ubuntu20.04': {
     chromium: [
+      'fonts-liberation',
       'libasound2',
       'libatk-bridge2.0-0',
       'libatk1.0-0',


### PR DESCRIPTION
Chrome and Edge both depend on the `fonts-liberation` package. This should make screenshots more consistent.