### PR TITLE
fix: broken API reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,5 @@ $ xvfb-run --auto-servernum -- npm test
 ## Resources
 
 * [Get started with Playwright](https://github.com/microsoft/playwright)
-* [Playwright API reference](https://github.com/microsoft/playwright/blob/master/docs/api.md)
+* [Playwright API reference](https://playwright.dev/docs/api/class-playwright/)
 * [Development docs](DEVELOPMENT.md)


### PR DESCRIPTION
# What is this?

Using this action for a demo and saw that the link to the API reference docs is broken. The microsoft/playwright points directly to the websites, which is what I changed. 