### PR TITLE
Add optional "browsers" and "headless" inputs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
     - uses: ./
+      with:
+        headless: ${{ matrix.headless }}
     - name: Install dependencies
       run: cd sample && npm install playwright@${{ matrix.playwright }}
       # Headless running is the same across OSes

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
 
 ### Upload artifacts
 
-This GitHub Action can be combined with the [Upload Artifact action](https://github.com/actions/upload-artifact) to upload test artifacts (like screenshots or logs).
+This GitHub action can be combined with the [Upload Artifact action](https://github.com/actions/upload-artifact) to upload test artifacts (like screenshots or logs).
 
 ```yml
 steps:
@@ -49,7 +49,16 @@ steps:
 
 ### Run in headful mode
 
-This GitHub Action can also execute tests in headful mode. To do this, use `xvfb-run` on a Linux agent.
+This GitHub action can also execute tests in headful mode. To do this, set the optional `headless` input to `false`.
+
+```yml
+steps:
+  - uses: microsoft/playwright-github-action@v1
+    with:
+      headless: false
+```
+
+Then use `xvfb-run` on a Linux agent.
 
 ```sh
 # Windows/macOS
@@ -59,8 +68,20 @@ $ npm test
 $ xvfb-run --auto-servernum -- npm test
 ```
 
+### Select browsers
+
+By default system dependencies for all browsers are installed, however, you can limit this to specific browsers only. Set the optional `browsers` input to a comma-separated list of the browsers you intend to launch.
+
+```yml
+steps:
+  - uses: microsoft/playwright-github-action@v1
+    with:
+      browsers: chromium, firefox, webkit
+```
+
 ## Resources
 
 * [Get started with Playwright](https://github.com/microsoft/playwright)
 * [Playwright API reference](https://playwright.dev/docs/api/class-playwright/)
+* [Playwright single browser binary install](https://playwright.dev/docs/installation/#download-single-browser-binary)
 * [Development docs](DEVELOPMENT.md)

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,15 @@ author: 'Microsoft'
 branding:
   icon: 'play'
   color: 'green'
+inputs:
+  browsers:
+    description: 'Comma-separated list of the browsers you intend to launch'
+    required: false
+    default: 'chromium, firefox, webkit'
+  headless:
+    description: 'Specify whether browsers will run in headless mode'
+    required: false
+    default: 'true'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -273,13 +273,13 @@ async function getUbuntuVersion() {
 }
 
 function getDependencies(osVersion, browsers) {
-  const deps = [];
+  let deps = [];
   browsers.forEach((browser) => {
     switch (browser) {
       case 'chromium':
       case 'firefox':
       case 'webkit':
-        deps.concat(DEPENDENCIES[osVersion][browser]);
+        deps = deps.concat(DEPENDENCIES[osVersion][browser]);
         break;
       default:
         throw new Error('Unrecognised browser ' + browser);


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-github-action/issues/17

## Changes

- Add optional `browsers` and `headless` action inputs + provide default values
- Document their use in the readme
- Only install system dependencies for the browsers specified in the action `browsers` input
- Only install headless system dependencies when the action `headless` input is _not_ `true`

## Notes

- If this PR is OK then then `.github/workflows/tests.yml` should be updated to also test installing a single browser — I didn't want to mangle the workflow too much without the OK from the package maintainers
- In the test workflow, the job is called `test-linux` but it's actually testing all the OSs... that should probably be updated to just `test`
- Since these changes are non-breaking, it should be safe to release as a minor version bump