### PR TITLE
docs: updating README for more clear directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Playwright GitHub Action
 
- ![ubuntu](https://github.com/microsoft/playwright-github-action/workflows/ubuntu/badge.svg) ![windows](https://github.com/microsoft/playwright-github-action/workflows/windows/badge.svg) ![macos](https://github.com/microsoft/playwright-github-action/workflows/macos/badge.svg)
+![ubuntu](https://github.com/microsoft/playwright-github-action/workflows/ubuntu/badge.svg) ![windows](https://github.com/microsoft/playwright-github-action/workflows/windows/badge.svg) ![macos](https://github.com/microsoft/playwright-github-action/workflows/macos/badge.svg)
 
 Set up GitHub Actions to run cross-browser tests on Chromium, WebKit and Firefox with [Playwright](https://github.com/microsoft/playwright).
 
@@ -20,8 +20,8 @@ Starting with Playwright v1.8.0 it [includes a CLI](https://playwright.dev/docs/
 ### To install dependencies with a CLI:
 
 ```sh
-$ npx playwright install-deps # install dependencies for all browsers
-$ npx playwright install-deps chromium # install dependencies for Chromium only
+npx playwright install-deps # install dependencies for all browsers
+npx playwright install-deps chromium # install dependencies for Chromium only
 ```
 
 ### Playwright CLI with GitHub Actions CI
@@ -39,12 +39,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
-      - name: install dependencies
+      - name: Install dependencies
         run: npm ci
-      - name: install playwright browsers
+      - name: Install playwright browsers
         run: npx playwright install --with-deps
-      - name: npm run test:e2e
-        run: npm run test:e2e
+      - name: Run tests
+        run: npx playwright test
 ```
 
 If something doesn't work, please [let us know](https://github.com/microsoft/playwright/issues/new)! 
@@ -102,10 +102,10 @@ This GitHub Action can also execute tests in headful mode. To do this, use `xvfb
 
 ```sh
 # Windows/macOS
-$ npm test
+npm test
 
 # Linux
-$ xvfb-run --auto-servernum -- npm test
+xvfb-run --auto-servernum -- npm test
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -4,21 +4,56 @@
 
 Set up GitHub Actions to run cross-browser tests on Chromium, WebKit and Firefox with [Playwright](https://github.com/microsoft/playwright).
 
-## ⚠️ **You don't need this GitHub Action** ⚠️
+## ❌ You don't need this GitHub Action
 
-**We recommend using Playwright CLI instead of this action**. 
+**We recommend using the Playwright CLI instead of this GitHub Action**.
 
-Since v1.8.0 Playwright [includes CLI](https://playwright.dev/docs/next/cli#install-system-dependencies) that installs all required browser dependencies. To install dependencies with CLI:
+One of the reasons for deprecating the GitHub Actions is that it doesn't know which version of Playwright is installed,
+which then requires installing many more dependencies to ensure support.
+
+We highly discourage the use of the GitHub Action. See next section for using the CLI.
+
+## ✅ Use the Playwright CLI
+
+Starting with Playwright v1.8.0 it [includes a CLI](https://playwright.dev/docs/next/cli#install-system-dependencies) that installs all required browser dependencies.
+
+### To install dependencies with a CLI:
 
 ```sh
 $ npx playwright install-deps # install dependencies for all browsers
 $ npx playwright install-deps chromium # install dependencies for Chromium only
 ```
 
+### Playwright CLI with GitHub Actions CI
+
+Following is an example usage of the Playwright CLI with a GitHub Actions workflow file.
+It shows a `tests_e2e` job which includes steps in which the Playwright CLI invokes the
+installation of required dependencies (headless browsers, etc) and then invokes the
+actual npm run script `npm run test:e2e` for the Playwright test runner:
+
+```yaml
+jobs:
+  tests_e2e:
+    name: Run end-to-end tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: install dependencies
+        run: npm ci
+      - name: install playwright browsers
+        run: npx playwright install --with-deps
+      - name: npm run test:e2e
+        run: npm run test:e2e
+```
+
 If something doesn't work, please [let us know](https://github.com/microsoft/playwright/issues/new)! 
 
 
-## Usage
+<details>
+ <summary>
+  ⚠️ GitHub Action Usage (deprecated)
+ </summary>
 
 Add `uses: microsoft/playwright-github-action@v1` to the GitHub workflow definition before running your tests.
 
@@ -73,6 +108,9 @@ $ npm test
 $ xvfb-run --auto-servernum -- npm test
 ```
 
+</details>
+ 
+ 
 ## Resources
 
 * [Get started with Playwright](https://github.com/microsoft/playwright)


### PR DESCRIPTION
This GitHub Actions README page was a bit confusing. While it is said to be deprecated, it isn't entirely clear how to use Playwright in a GitHub Actions CI, and also the usage section for the GitHub Actions workflow was still very much apparent, creating more confusion.

This PR introduces:
- Clearer "DOs and DONTs"
- Shows a GitHub Actions workflow CI configuration
- Elaborate on why it is deprecated
- Cleans up the README