### PR TITLE
chore: make sure Playwright installs browsers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,10 +48,10 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: 18
     - uses: ./
     - name: Install dependencies
-      run: cd sample && npm install playwright@${{ matrix.playwright }}
+      run: cd sample && npm install playwright@${{ matrix.playwright }} && npx playwright install
       # Headless running is the same across OSes
     - name: Run Playwright (headless)
       if: ${{ matrix.headless == true }}


### PR DESCRIPTION
The upcoming Playwright 1.38 library does not install browsers by default, so we have to install them explicitly.