### PR TITLE
chore: use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ branding:
   icon: 'play'
   color: 'green'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
16 is EOL and creates warnings, 18 gets skipped at GitHub, 20 is what they recommend.

See https://github.com/actions/runner/issues/2619#issuecomment-1643716450 that they don't provide `node18`.