### PR TITLE
chore: deprecate GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ We highly discourage the use of the GitHub Action. See next section for using th
 
 ## ✅ Use the Playwright CLI
 
-Starting with Playwright v1.8.0 it [includes a CLI](https://playwright.dev/docs/next/cli#install-system-dependencies) that installs all required browser dependencies.
+Starting with Playwright v1.8.0 it [includes a CLI](https://playwright.dev/docs/cli#install-system-dependencies) that installs all required browser dependencies.
 
 ### To install dependencies with a CLI:
 
 ```sh
-npx playwright install-deps # install dependencies for all browsers
-npx playwright install-deps chromium # install dependencies for Chromium only
+npx playwright install --with-deps # install browsers + dependencies for all browsers
+npx playwright install chromium --with-deps # install browsers + dependencies for Chromium only
 ```
 
 ### Playwright CLI with GitHub Actions CI

--- a/dist/index.js
+++ b/dist/index.js
@@ -4504,6 +4504,7 @@ const DEPENDENCIES = {
 };
 
 async function run() {
+  core.warning('This GitHub Action is deprecated. We recommend installing dependencies via \'npx playwright install --with-deps\' instead. See https://playwright.dev/docs/cli#install-system-dependencies for more information.');
   try {
     if (os.platform() === 'linux') {
       await exec('sudo', ['apt-get', 'update']);

--- a/index.js
+++ b/index.js
@@ -394,6 +394,7 @@ const DEPENDENCIES = {
 };
 
 async function run() {
+  core.warning('This GitHub Action is deprecated. We recommend installing dependencies via \'npx playwright install --with-deps\' instead. See https://playwright.dev/docs/cli#install-system-dependencies for more information.');
   try {
     if (os.platform() === 'linux') {
       await exec('sudo', ['apt-get', 'update']);


### PR DESCRIPTION
This looks similar to normal GitHub Action deprecations and follows their pattern.

Reason for deprecation is that GitHub Actions is not able to install a specific Playwright version's dependencies and installing the dependencies of a specific Playwright browser. See [here](https://playwright.dev/docs/browsers#install-browsers) for the replacement.